### PR TITLE
Added support for Ubuntu-1804. Fix libapache2-svn to libapache2-mod-svn packaging issue.

### DIFF
--- a/meta/.galaxy_install_info
+++ b/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Sat Sep 22 18:30:21 2018', version: 1.2.4}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,15 @@
 ---
 - name: Include OS-specific variables.
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_tasks: variables.yml
 
 - name: Ensure SVN packages are installed.
   yum: "name={{ item }} state=present"
-  with_items:
-    - mod_dav_svn
-    - subversion
+  with_items: "{{ svn_packages }}"
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure SVN packages are installed (Debian).
   apt: "name={{ item }} state=present"
-  with_items:
-    - subversion
-    - libapache2-svn
+  with_items: "{{ svn_packages }}"
   when: ansible_os_family == 'Debian'
 
 - name: Ensure svn home folder exists.

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,0 +1,8 @@
+---
+- name: Include OS-specific variables (Debian).
+  include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
+  when: ansible_os_family == 'Debian'
+
+- name: Include OS-specific variables (RedHat).
+  include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
+  when: ansible_os_family == 'RedHat'

--- a/vars/Debian-7.yml
+++ b/vars/Debian-7.yml
@@ -1,0 +1,7 @@
+---
+svn_apache_user: www-data
+svn_apache_conf_path: /etc/apache2/sites-enabled
+svn_packages:
+  - subversion
+  - libapache2-svn
+

--- a/vars/Debian-8.yml
+++ b/vars/Debian-8.yml
@@ -1,0 +1,7 @@
+---
+svn_apache_user: www-data
+svn_apache_conf_path: /etc/apache2/sites-enabled
+svn_packages:
+  - subversion
+  - libapache2-svn
+

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,0 +1,7 @@
+---
+svn_apache_user: www-data
+svn_apache_conf_path: /etc/apache2/sites-enabled
+svn_packages:
+  - subversion
+  - libapache2-svn
+

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -1,3 +1,6 @@
 ---
 svn_apache_user: apache
 svn_apache_conf_path: /etc/httpd/conf.d
+svn_packages:
+  - mod_dav_svn
+  - subversion

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -1,0 +1,6 @@
+---
+svn_apache_user: apache
+svn_apache_conf_path: /etc/httpd/conf.d
+svn_packages:
+  - mod_dav_svn
+  - subversion

--- a/vars/Ubuntu-14.yml
+++ b/vars/Ubuntu-14.yml
@@ -1,3 +1,6 @@
 ---
 svn_apache_user: www-data
 svn_apache_conf_path: /etc/apache2/sites-enabled
+svn_packages:
+  - subversion
+  - libapache2-svn

--- a/vars/Ubuntu-16.yml
+++ b/vars/Ubuntu-16.yml
@@ -1,0 +1,6 @@
+---
+svn_apache_user: www-data
+svn_apache_conf_path: /etc/apache2/sites-enabled
+svn_packages:
+  - subversion
+  - libapache2-svn

--- a/vars/Ubuntu-18.yml
+++ b/vars/Ubuntu-18.yml
@@ -1,0 +1,6 @@
+---
+svn_apache_user: www-data
+svn_apache_conf_path: /etc/apache2/sites-enabled
+svn_packages:
+  - subversion
+  - libapache2-mod-svn


### PR DESCRIPTION
Added support for ubuntu-1804 by including variables based on **ansible_distribution** and **ansible_distribution_version** in addition to **ansible_os_family**. This allows us to isolate Ubuntu 1804 variables in the /vars/Ubuntu-18.yml. This is the pattern used to handle multiple OS families and versions in the [geerlingguy.postgresql](https://github.com/geerlingguy/ansible-role-postgresql/blob/master/tasks/variables.yml) Ansible role. This is in response to this [issue 5](https://github.com/geerlingguy/ansible-role-svn/issues/5)