### PR TITLE
This ensures the correct SELinux context is set up when creating new repositories

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 svn_repository_home: /var/svn
-svn_create_test_repo: true
+svn_public_repos: true
+svn_repos:
+  - reponame: testrepo

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ svn_repository_home: /var/svn
 svn_public_repos: true
 svn_repos:
   - reponame: testrepo
+    realm: "Test repository"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,12 +43,12 @@
     mode: 0644
   notify: restart apache
 
-- name: Create a test repository.
+- name: Create SVN repositories
   command: >
-    svnadmin create testrepo
+    svnadmin create {{ item.reponame }}
     chdir={{ svn_repository_home }}
-    creates={{ svn_repository_home }}/testrepo/README.txt
-  when: svn_create_test_repo
+    creates={{ svn_repository_home }}/{{ item.reponame }}/README.txt
+  loop: "{{ svn_repos }}"
 
 - name: Apply new SELinux file context to filesystem
   command: restorecon -irv "{{ svn_repository_home }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,18 +12,21 @@
     target: "{{ svn_repository_home | regex_replace('\\/$', '') }}/[^/]*(/.*)?"
     setype: httpd_sys_rw_content_t
     state: present
+  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
 
 - name: Allow apache to modify SVN config files in svn_repository_home
   sefcontext:
     target: "{{ svn_repository_home | regex_replace('\\/$', '') }}/[^/]*/conf(/.*)?"
     setype: httpd_sys_content_t
     state: present
+  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
 
 - name: Allow apache to modify SVN hooks in svn_repository_home
   sefcontext:
     target: "{{ svn_repository_home | regex_replace('\\/$', '') }}/[^/]*/hooks(/.*)?"
     setype: httpd_sys_script_exec_t
-    state: present 
+    state: present
+  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
 
 - name: Ensure svn home folder exists.
   file:
@@ -49,6 +52,7 @@
 
 - name: Apply new SELinux file context to filesystem
   command: restorecon -irv "{{ svn_repository_home }}"
+  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
 
 - name: Set ownership for svn directories.
   file:  # noqa 208

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,21 +12,21 @@
     target: "{{ svn_repository_home | regex_replace('\\/$', '') }}/[^/]*(/.*)?"
     setype: httpd_sys_rw_content_t
     state: present
-  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
+  when: ansible_selinux is defined and ansible_selinux and ansible_selinux.status == 'enabled'
 
 - name: Allow apache to modify SVN config files in svn_repository_home
   sefcontext:
     target: "{{ svn_repository_home | regex_replace('\\/$', '') }}/[^/]*/conf(/.*)?"
     setype: httpd_sys_content_t
     state: present
-  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
+  when: ansible_selinux is defined and ansible_selinux and ansible_selinux.status == 'enabled'
 
 - name: Allow apache to modify SVN hooks in svn_repository_home
   sefcontext:
     target: "{{ svn_repository_home | regex_replace('\\/$', '') }}/[^/]*/hooks(/.*)?"
     setype: httpd_sys_script_exec_t
     state: present
-  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
+  when: ansible_selinux is defined and ansible_selinux and ansible_selinux.status == 'enabled'
 
 - name: Ensure svn home folder exists.
   file:
@@ -52,7 +52,7 @@
 
 - name: Apply new SELinux file context to filesystem
   command: restorecon -irv "{{ svn_repository_home }}"
-  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
+  when: ansible_selinux is defined and ansible_selinux and ansible_selinux.status == 'enabled'
 
 - name: Set ownership for svn directories.
   file:  # noqa 208

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,24 @@
     name: "{{ svn_packages }}"
     state: present
 
+- name: Allow apache to modify files in svn_repository_home
+  sefcontext:
+    target: "{{ svn_repository_home | regex_replace('\\/$', '') }}/[^/]*(/.*)?"
+    setype: httpd_sys_rw_content_t
+    state: present
+
+- name: Allow apache to modify SVN config files in svn_repository_home
+  sefcontext:
+    target: "{{ svn_repository_home | regex_replace('\\/$', '') }}/[^/]*/conf(/.*)?"
+    setype: httpd_sys_content_t
+    state: present
+
+- name: Allow apache to modify SVN hooks in svn_repository_home
+  sefcontext:
+    target: "{{ svn_repository_home | regex_replace('\\/$', '') }}/[^/]*/hooks(/.*)?"
+    setype: httpd_sys_script_exec_t
+    state: present 
+
 - name: Ensure svn home folder exists.
   file:
     path: "{{ svn_repository_home }}"
@@ -28,6 +46,9 @@
     chdir={{ svn_repository_home }}
     creates={{ svn_repository_home }}/testrepo/README.txt
   when: svn_create_test_repo
+
+- name: Apply new SELinux file context to filesystem
+  command: restorecon -irv "{{ svn_repository_home }}"
 
 - name: Set ownership for svn directories.
   file:  # noqa 208

--- a/templates/subversion.conf.j2
+++ b/templates/subversion.conf.j2
@@ -1,6 +1,3 @@
-LoadModule dav_svn_module     modules/mod_dav_svn.so
-LoadModule authz_svn_module   modules/mod_authz_svn.so
-
 <Location /svn>
    DAV svn
    SVNParentPath {{ svn_repository_home }}

--- a/templates/subversion.conf.j2
+++ b/templates/subversion.conf.j2
@@ -14,7 +14,7 @@ LoadModule authz_svn_module   modules/mod_authz_svn.so
     SVNPath {{ svn_repository_home }}/{{ repo.reponame }}
     AuthzSVNAccessFile {{ svn_repository_home }}/{{ repo.reponame }}/conf/authz
     AuthType Basic
-    AuthName "{{ repo.reponame }}"
+    AuthName "{{ repo.realm }}"
     AuthUserFile {{ svn_repository_home }}/.dav_svn.passwd
     Require valid-user
     LimitXMLRequestBody 0

--- a/templates/subversion.conf.j2
+++ b/templates/subversion.conf.j2
@@ -1,8 +1,24 @@
 LoadModule dav_svn_module     modules/mod_dav_svn.so
 LoadModule authz_svn_module   modules/mod_authz_svn.so
 
+{% if svn_public_repos %}
 <Location /svn>
    DAV svn
    SVNParentPath {{ svn_repository_home }}
    Allow from All
 </Location>
+{% else %}
+{% for repo in svn_repos %}
+<Location /{{ repo.reponame }}>
+    DAV svn
+    SVNPath {{ svn_repository_home }}/{{ repo.reponame }}
+    AuthzSVNAccessFile {{ svn_repository_home }}/{{ repo.reponame }}/conf/authz
+    AuthType Basic
+    AuthName "{{ repo.reponame }}"
+    AuthUserFile {{ svn_repository_home }}/.dav_svn.passwd
+    Require valid-user
+    LimitXMLRequestBody 0
+    LimitRequestBody 0
+</Location>
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
By setting the SELinux context after creating the repository this avoids SELinux denials.
Fixes #7 .